### PR TITLE
Use inspect.getfullargspec() instead of inspect.getargspec() 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ python:
   - "2.7"
   - "3.6"
   - "3.7"
-  - "nightly"
+  - "3.8"
+  - "3.9"
   - "pypy3.5"
 install:
   - pip install pytest

--- a/anticipate/decorators.py
+++ b/anticipate/decorators.py
@@ -1,14 +1,21 @@
 from __future__ import absolute_import
 
 from functools import partial, update_wrapper
-import inspect
 
 from builtins import zip
 from builtins import object
 
 from anticipate.adapt import AdaptError, AdaptErrors, adapt, adapt_all, register_adapter
 from anticipate.exceptions import AnticipateErrors, AnticipateParamError
-
+try:
+    # Support for python 3
+    from inspect import getfullargspec
+except ImportError:
+    # Support for python 2
+    from inspect import getargspec
+else:
+    def getargspec(func):
+        return getfullargspec(func)[:4]
 
 __all__ = [
     'adapter',
@@ -32,7 +39,7 @@ class anticipate_wrapper(object):
         self._adapt_result = self._get_adapter(self.returns) if self.returns else None
         self.strict = strict
 
-        args, _, kwargs, _ = inspect.getargspec(func)
+        args, _, kwargs, _ = getargspec(func)
 
         self.arg_names = args
 


### PR DESCRIPTION
This makes it compatible with python3 too.